### PR TITLE
feat(Slider): Fixing alignment of sliderlabel

### DIFF
--- a/scss/components/slider.scss
+++ b/scss/components/slider.scss
@@ -56,10 +56,7 @@
 
       &.#{$slider__class}__hashlabel {
         top: 15px;
-        min-width: 17px;
         display: inline-block;
-        text-align: center;
-        left: -6px;
         line-height: 12px;
         color: $slider-hashlabel__color;
 


### PR DESCRIPTION
Fixing alignment issue of slider label
<img width="81" alt="screen shot 2018-04-30 at 2 56 36 pm" src="https://user-images.githubusercontent.com/3319024/39421450-b6d31314-4c86-11e8-8bd0-500ffd212756.png">
@pauljeter @collab-ui/collab-jedi 