### PR TITLE
feat(accordion): Adding group separator for accordion

### DIFF
--- a/scss/components/accordian.scss
+++ b/scss/components/accordian.scss
@@ -25,6 +25,7 @@
         color: $accordion__color;
         cursor: pointer;
         justify-content: space-between;
+        border-bottom: $accordion-separator__border;
         > .cui-accordion__header-icon:before {
           @include icon-arrow-down_16;
           font-family: $icon-font-name;

--- a/scss/components/accordian.scss
+++ b/scss/components/accordian.scss
@@ -25,12 +25,15 @@
         color: $accordion__color;
         cursor: pointer;
         justify-content: space-between;
-        border-bottom: $accordion-separator__border;
         > .cui-accordion__header-icon:before {
           @include icon-arrow-down_16;
           font-family: $icon-font-name;
           font-size: $accordion-arrow__font-size;
           font-weight: normal;
+        }
+
+        &.cui-accordion__header--separator {
+          border-bottom: $accordion-separator__border;
         }
       }
       > .cui-accordion__content {

--- a/scss/settings/accordion.scss
+++ b/scss/settings/accordion.scss
@@ -1,4 +1,5 @@
 @import "../settings/fonts";
+@import "../settings/colors";
 $accordion-header__padding: rem-calc(10) !default;
 $accordion__color: $black !default;
 $accordion__font-size: rem-calc(16) !default;
@@ -9,3 +10,4 @@ $accordion-list-item__padding: rem-calc(10);
 $accordion-content-padding: ($column-gutter/2) !default;
 $accordion-content__background: $white !default;
 $accordion-arrow__font-size: rem-calc(12);
+$accordion-separator__border: rem-calc(1) solid $black-08;


### PR DESCRIPTION
<img width="1067" alt="screen shot 2018-05-02 at 12 15 46 pm" src="https://user-images.githubusercontent.com/3319024/39509111-ab1b8fe2-4e02-11e8-9477-e3a09874c4ea.png">
@pauljeter @bfbiggs @collab-ui/collab-jedi 
@pauljeter We might have to update the styling for hover/focus/pressed state of accordion-header also, these styling are not there currently.