### PR TITLE
fix(menu-overlay): remove hardcoded width for menu item

### DIFF
--- a/scss/components/menu-overlay.scss
+++ b/scss/components/menu-overlay.scss
@@ -21,7 +21,6 @@
 
       > .#{$menu__class} {
         .#{$list-item__class} {
-          width: $menu-item__width;
           height: $menu-item__height;
           padding: 0 $menu-item__padding;
           border-radius: 0;


### PR DESCRIPTION
Before:
<img width="553" alt="screen shot 2018-08-02 at 12 42 36 pm" src="https://user-images.githubusercontent.com/36969382/43600924-972d5faa-9651-11e8-8ad8-3c69668d8602.png">

After:
<img width="529" alt="screen shot 2018-08-02 at 12 40 11 pm" src="https://user-images.githubusercontent.com/36969382/43600899-8431fb18-9651-11e8-8333-8665f9b9168a.png">
