### PR TITLE
fix(menu-overlay): add separate class name for isHeader

### DIFF
--- a/scss/components/menu-overlay.scss
+++ b/scss/components/menu-overlay.scss
@@ -21,7 +21,6 @@
 
       > .#{$menu__class} {
         .#{$list-item__class} {
-          width: $menu-item__width;
           height: $menu-item__height;
           padding: 0 $menu-item__padding;
           border-radius: 0;

--- a/scss/components/menu-overlay.scss
+++ b/scss/components/menu-overlay.scss
@@ -49,12 +49,12 @@
             display: flex;
             padding-left: $menu-item-arrow__padding-left;
           }
-        }
 
-        .#{$list-item__class}--read-only {
-          height: $menu-item-header__height;
-          font-size: $menu-item-header__font-size;
-          opacity: $menu-item-header__opacity;
+          &__header {
+            height: $menu-item-header__height;
+            font-size: $menu-item-header__font-size;
+            opacity: $menu-item-header__opacity;
+          }
         }
       }
 


### PR DESCRIPTION
Before:
<img width="553" alt="screen shot 2018-08-02 at 12 42 36 pm" src="https://user-images.githubusercontent.com/36969382/43600924-972d5faa-9651-11e8-8ad8-3c69668d8602.png">

After:
<img width="529" alt="screen shot 2018-08-02 at 12 40 11 pm" src="https://user-images.githubusercontent.com/36969382/43600899-8431fb18-9651-11e8-8333-8665f9b9168a.png">
