### PR TITLE
style(EditableTextfield): add no-break space to prevent div collapsin…

### DIFF
--- a/scss/components/editable-textfield.scss
+++ b/scss/components/editable-textfield.scss
@@ -13,7 +13,7 @@
 
 @include exports('cui-editable-textfield') {
   .#{$cui}-editable-textfield {
-    
+
     & > &__button {
       @include radius($global-radius);
 
@@ -26,6 +26,9 @@
         .#{$dark-class} & {
           background-color: $white-24;
         }
+      }
+      &:before {
+        content: '\00a0';
       }
     }
 


### PR DESCRIPTION
…g on empty value
related collab-ui-react PR: https://github.com/collab-ui/collab-ui-react/pull/130
related collab-ui-react issue: https://github.com/collab-ui/collab-ui-react/issues/129
