### PR TITLE
fix(avatar): add hover/pressed states when clickable

### DIFF
--- a/scss/components/avatar.scss
+++ b/scss/components/avatar.scss
@@ -111,6 +111,23 @@
       display: none;
     }
 
+    &.#{$avatar__class}--clickable:after {
+      @include avatar-contents-base;
+
+      position: absolute;
+      content: '';
+    }
+
+    &.#{$avatar__class}--clickable {
+      &:hover::after {
+        @include avatar-overlay-style($white, $black_08);
+      }
+
+      &:active::after {
+        @include avatar-overlay-style($white, $black_16);
+      }
+    }
+
     &.#{$avatar__class}--active:after {
       @include avatar-contents-base;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/collab-ui/collab-ui-core/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
resolves https://github.com/collab-ui/collab-ui-core/issues/90
When an Avatar is clickable, there is not a css change when the user hovers or presses the avatar.


**What is the new behavior?**
When a user hovers over a clickable avatar, the avatar becomes a slightly darker. If a user presses on a clickable avatar, the avatar becomes a bit more darker than hover.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
