### PR TITLE
fix(panel): correct position of clear icon button within Input Component

### DIFF
--- a/scss/components/input.scss
+++ b/scss/components/input.scss
@@ -419,7 +419,7 @@
       z-index: $input__focus-z-index + 1;
     }
 
-    .#{$cui}-input--icon,
+    .#{$cui}-input__icon,
     .#{$cui}-button--icon {
       right: rem-calc(11);
       left: auto;

--- a/scss/components/input.scss
+++ b/scss/components/input.scss
@@ -419,6 +419,7 @@
       z-index: $input__focus-z-index + 1;
     }
 
+    .#{$cui}-input--icon,
     .#{$cui}-button--icon {
       right: rem-calc(11);
       left: auto;

--- a/scss/components/panel.scss
+++ b/scss/components/panel.scss
@@ -235,16 +235,16 @@
       }
 
       .#{$input__class}__icon-container {
-        .#{$button__class},
         .#{$input__class} {
-          padding-right: 2.25rem;
+          padding-right: rem-calc(36);
+        }
 
-          &--icon {
-            background: transparent;
+        .#{$input__class}__icon,
+        .#{$button__class}--icon {
+          background: transparent;
             border: 0;
             min-height: 0;
             padding: 0;
-          }
         }
       }
 

--- a/scss/components/panel.scss
+++ b/scss/components/panel.scss
@@ -242,9 +242,9 @@
         .#{$input__class}__icon,
         .#{$button__class}--icon {
           background: transparent;
-            border: 0;
-            min-height: 0;
-            padding: 0;
+          border: 0;
+          min-height: 0;
+          padding: 0;
         }
       }
 

--- a/scss/components/panel.scss
+++ b/scss/components/panel.scss
@@ -258,8 +258,8 @@
         @media #{$medium-up} {
           width: rem-calc(320);
 
-          &--icon {
-            width: unset;
+          &.#{$button__class}--icon {
+            width: auto;
           }
         }
       }

--- a/scss/components/panel.scss
+++ b/scss/components/panel.scss
@@ -234,6 +234,20 @@
         }
       }
 
+      .#{$input__class}__icon-container {
+        .#{$button__class},
+        .#{$input__class} {
+          padding-right: 2.25rem;
+
+          &--icon {
+            background: transparent;
+            border: 0;
+            min-height: 0;
+            padding: 0;
+          }
+        }
+      }
+
       .#{$button__class},
       .#{$input__class} {
         min-height: $panel-input__height;
@@ -243,6 +257,10 @@
 
         @media #{$medium-up} {
           width: rem-calc(320);
+
+          &--icon {
+            width: unset;
+          }
         }
       }
 


### PR DESCRIPTION
This also includes a css adjustment for the new Input prop, Icon node.
resolves #135 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/collab-ui/collab-ui-core/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
Within a panel-form, the clear button is not aligned correctly.
<img width="311" alt="screen shot 2018-10-30 at 8 39 57 am" src="https://user-images.githubusercontent.com/15151981/47730508-8a77bd00-dc1f-11e8-939e-600cadeb631e.png">

**What is the new behavior?**
We have aligned the clear button, to the right of the input field when it is in a panel-form.
<img width="308" alt="screen shot 2018-10-30 at 8 53 43 am" src="https://user-images.githubusercontent.com/15151981/47731438-5dc4a500-dc21-11e8-9ec6-1ca7ace90541.png">


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Also requires collab-ui-react for full fix