### PR TITLE
fix(Panel): second attempt to fix input clear button within cui-panel

### DIFF
--- a/scss/components/panel.scss
+++ b/scss/components/panel.scss
@@ -139,7 +139,7 @@
       align-items: center;
     }
 
-    .#{$button__class},
+    &__cta .#{$button__class},
     .#{$input__class} {
       height: $panel-input__height;
 


### PR DESCRIPTION
This fix goes with the expectation that the developer using the collab-ui toolkit will wrap any button (besides the icon-button within the Input field) with the `cui-panel__cta` class.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/collab-ui/collab-ui-core/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
<img width="373" alt="screen shot 2018-11-01 at 8 38 42 pm" src="https://user-images.githubusercontent.com/15151981/47892829-17d13200-de17-11e8-8306-1b531e437ffb.png">
<img width="441" alt="screen shot 2018-11-01 at 8 38 54 pm" src="https://user-images.githubusercontent.com/15151981/47892835-1acc2280-de17-11e8-8636-b08bbbfa61e8.png">



**What is the new behavior?**
<img width="377" alt="screen shot 2018-11-01 at 8 44 31 pm" src="https://user-images.githubusercontent.com/15151981/47892838-1e5fa980-de17-11e8-892e-00c3d29ac40e.png">
<img width="267" alt="screen shot 2018-11-01 at 8 44 49 pm" src="https://user-images.githubusercontent.com/15151981/47892842-215a9a00-de17-11e8-934e-5300f01a4710.png">



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
