### PR TITLE
content-item wide fix

### DIFF
--- a/scss/components/content-item.scss
+++ b/scss/components/content-item.scss
@@ -13,17 +13,21 @@
   background-size: cover;
   border: 1px solid $black-06;
   border-radius: 4px;
-  box-shadow: inset 1px 0 0 0 $black-06,
-    inset -1px 0 0 0 $black-06;
+  box-shadow: inset 1px 0 0 0 $black-06, inset -1px 0 0 0 $black-06;
 }
 
-@mixin file-aspect($width, $height, $margin: null) {
+@mixin file-aspect($width, $height, $margin: null, $bSize: null) {
   width: $width;
   height: $height;
   margin: $margin;
   background-position: center;
   background-repeat: no-repeat;
-  background-size: cover;
+
+  @if $bSize {
+    background-size: $bSize;
+  } @else {
+    background-size: cover;
+  }
 }
 
 @include exports('cui-content-item') {
@@ -40,7 +44,23 @@
       display: flex;
     }
 
+    &__gif {
+      position: absolute;
+      top: 0.2rem;
+      right: 0.5rem;
+
+      &--oneOne {
+        right: 2.6rem;
+      }
+
+      &--fourThree {
+        right: 1.3rem;
+      }
+    }
+
     &__container {
+      @include flex($fd: column);
+
       width: 204px;
       height: 190px;
     }
@@ -269,10 +289,7 @@
     }
 
     &--sixteen-nine {
-      @include file-aspect(100%, 116px, 10px 0);
-
-      position: relative;
-      top: 0.6rem;
+      @include file-aspect(100%, 116px, 10px 0, contain);
     }
 
     &--nine-sixteen {
@@ -282,7 +299,6 @@
     &--one-one {
       @include file-aspect(136px, 136px, 0 auto);
 
-      border: 1px solid $black-06;
       border-radius: 4px;
     }
 
@@ -325,11 +341,5 @@
 
   .content-file--no-border {
     box-shadow: none;
-  }
-
-  .cui-content__gif {
-    position: absolute;
-    top: 0.2rem;
-    right: 0.5rem;
   }
 }


### PR DESCRIPTION


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/collab-ui/collab-ui-core/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**

the wide aspect in File Content Item will now line up correctly next to other content items horizontally

took our border on oneOne

gifIcons needed to move slightly to the left on file oneOne and fourThree 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
