### PR TITLE
fix(content-item): fix alignment when title/subtitle is null

### DIFF
--- a/scss/components/content-item.scss
+++ b/scss/components/content-item.scss
@@ -59,7 +59,7 @@
     }
 
     &__container {
-      @include flex($fd: column);
+      @include flex($fd: column, $jc: flex-start);
 
       width: 204px;
       height: 190px;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/collab-ui/collab-ui-core/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)

contentItem moves downward when title/subtitle doesn't exist

**What is the new behavior?**

Fixed with flex-start. 

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
